### PR TITLE
build: include Darwin ARM64 build

### DIFF
--- a/cmd/zbctl/build.sh
+++ b/cmd/zbctl/build.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -xeu
 
-OS=( linux windows darwin )
-BINARY=( zbctl zbctl.exe zbctl.darwin )
+OS=( linux windows darwin darwin )
+ARCH=( amd64 amd64 amd64 arm64 )
+BINARY=( zbctl zbctl.exe zbctl.darwin-amd64 zbctl.darwin-arm64 )
+
 SRC_DIR=$(dirname "${BASH_SOURCE[0]}")
 DIST_DIR="$SRC_DIR/dist"
 
@@ -13,7 +15,7 @@ rm -rf ${DIST_DIR}/*
 
 for i in "${!OS[@]}"; do
 	if [ $# -eq 0 ] || [ ${OS[$i]} = $1 ]; then
-	    CGO_ENABLED=0 GOOS="${OS[$i]}" GOARCH=amd64 go build -a -tags netgo -ldflags "-w -X github.com/camunda-community-hub/zeebe-client-go/v8/cmd/zbctl/internal/commands.Version=${VERSION} -X github.com/camunda-community-hub/zeebe-client-go/v8/cmd/zbctl/internal/commands.Commit=${COMMIT}" -o "${DIST_DIR}/${BINARY[$i]}" "${SRC_DIR}/main.go" &
+	    CGO_ENABLED=0 GOOS="${OS[$i]}" GOARCH="${ARCH[$i]}" go build -a -tags netgo -ldflags "-w -X github.com/camunda-community-hub/zeebe-client-go/v8/cmd/zbctl/internal/commands.Version=${VERSION} -X github.com/camunda-community-hub/zeebe-client-go/v8/cmd/zbctl/internal/commands.Commit=${COMMIT}" -o "${DIST_DIR}/${BINARY[$i]}" "${SRC_DIR}/main.go" &
 	fi
 done
 


### PR DESCRIPTION
Currently we're only building for Darwin AMD64 (x64), but the default architecture for recent Macbooks is ARM64.
This PR includes a new binary to be built for ARM64 architecture (binary name `zbctl.darwin-arm64`). The AMD64 flavor will be built as `zbctl.darwin-amd64`.

---

Tested by running locally:

```
./cmd/zbctl/build.sh

+ OS=(linux windows darwin darwin)
+ ARCH=(amd64 amd64 amd64 arm64)
+ BINARY=(zbctl zbctl.exe zbctl.darwin-amd64 zbctl.darwin-arm64)
++ dirname ./cmd/zbctl/build.sh
+ SRC_DIR=./cmd/zbctl
+ DIST_DIR=./cmd/zbctl/dist
+ VERSION=development
++ git rev-parse HEAD
+ COMMIT=173f92a824dfa6508a6311d98a00c579b9f9690b
+ mkdir -p ./cmd/zbctl/dist
+ rm -rf ./cmd/zbctl/dist/zbctl ./cmd/zbctl/dist/zbctl.darwin-amd64 ./cmd/zbctl/dist/zbctl.darwin-arm64 ./cmd/zbctl/dist/zbctl.exe
+ for i in '"${!OS[@]}"'
+ '[' 0 -eq 0 ']'
+ for i in '"${!OS[@]}"'
+ '[' 0 -eq 0 ']'
+ CGO_ENABLED=0
+ GOOS=linux
+ GOARCH=amd64
+ go build -a -tags netgo -ldflags '-w -X github.com/camunda-community-hub/zeebe-client-go/v8/cmd/zbctl/internal/commands.Version=development -X github.com/camunda-community-hub/zeebe-client-go/v8/cmd/zbctl/internal/commands.Commit=173f92a824dfa6508a6311d98a00c579b9f9690b' -o ./cmd/zbctl/dist/zbctl ./cmd/zbctl/main.go
+ for i in '"${!OS[@]}"'
+ '[' 0 -eq 0 ']'
+ CGO_ENABLED=0
+ GOOS=windows
+ GOARCH=amd64
+ go build -a -tags netgo -ldflags '-w -X github.com/camunda-community-hub/zeebe-client-go/v8/cmd/zbctl/internal/commands.Version=development -X github.com/camunda-community-hub/zeebe-client-go/v8/cmd/zbctl/internal/commands.Commit=173f92a824dfa6508a6311d98a00c579b9f9690b' -o ./cmd/zbctl/dist/zbctl.exe ./cmd/zbctl/main.go
+ for i in '"${!OS[@]}"'
+ '[' 0 -eq 0 ']'
+ CGO_ENABLED=0
+ GOOS=darwin
+ GOARCH=amd64
+ go build -a -tags netgo -ldflags '-w -X github.com/camunda-community-hub/zeebe-client-go/v8/cmd/zbctl/internal/commands.Version=development -X github.com/camunda-community-hub/zeebe-client-go/v8/cmd/zbctl/internal/commands.Commit=173f92a824dfa6508a6311d98a00c579b9f9690b' -o ./cmd/zbctl/dist/zbctl.darwin-amd64 ./cmd/zbctl/main.go
+ wait
+ CGO_ENABLED=0
+ GOOS=darwin
+ GOARCH=arm64
+ go build -a -tags netgo -ldflags '-w -X github.com/camunda-community-hub/zeebe-client-go/v8/cmd/zbctl/internal/commands.Version=development -X github.com/camunda-community-hub/zeebe-client-go/v8/cmd/zbctl/internal/commands.Commit=173f92a824dfa6508a6311d98a00c579b9f9690b' -o ./cmd/zbctl/dist/zbctl.darwin-arm64 ./cmd/zbctl/main.go
```

result:
```
ls -l cmd/zbctl/dist
total 103776
-rwxr-xr-x  1 maxim.danilov  staff  13182711 Oct 25 21:14 zbctl
-rwxr-xr-x  1 maxim.danilov  staff  13373408 Oct 25 21:14 zbctl.darwin-amd64
-rwxr-xr-x  1 maxim.danilov  staff  13020274 Oct 25 21:14 zbctl.darwin-arm64
-rwxr-xr-x  1 maxim.danilov  staff  13550592 Oct 25 21:14 zbctl.exe
```