### PR TITLE
feat: add in-memory OAuth token cache for read-only containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ export ZEEBE_AUTHORIZATION_SERVER_URL='[OAuth API]'
 
 When you create client credentials in Camunda 8, you have the option to download a file with the lines above filled out for you.
 
+If you are running in a read-only filesystem (e.g. a container with `readOnlyRootFilesystem: true`), you can disable the disk-based token cache by setting:
+
+```bash
+export CAMUNDA_TOKEN_DISK_CACHE_DISABLE=true
+```
+
+This will use an in-memory credentials cache instead of writing to `~/.camunda/credentials`. Note that tokens will not survive process restarts when using this option.
+
 Given these environment variables, you can instantiate the client as follows:
 
 ```go

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ When you create client credentials in Camunda 8, you have the option to download
 If you are running in a read-only filesystem (e.g. a container with `readOnlyRootFilesystem: true`), you can disable the disk-based token cache by setting:
 
 ```bash
-export CAMUNDA_TOKEN_DISK_CACHE_DISABLE=true
+export ZEEBE_CLIENT_DISK_CACHE_DISABLE=true
 ```
 
 This will use an in-memory credentials cache instead of writing to `~/.camunda/credentials`. Note that tokens will not survive process restarts when using this option.

--- a/pkg/zbc/oauthCredentialsCache.go
+++ b/pkg/zbc/oauthCredentialsCache.go
@@ -27,7 +27,7 @@ import (
 )
 
 const OAuthCachePathEnvVar = "ZEEBE_CLIENT_CONFIG_PATH"
-const OAuthCacheDiskDisableEnvVar = "CAMUNDA_TOKEN_DISK_CACHE_DISABLE"
+const OAuthCacheDiskDisableEnvVar = "ZEEBE_CLIENT_DISK_CACHE_DISABLE"
 const DefaultOAuthCacheFileDir = ".camunda"
 const DefaultOAuthCacheFile = "credentials"
 const oauthYamlCredentialsCachePerm = 0660
@@ -200,7 +200,7 @@ func ensureOAuthCachePathSegmentsExist(directory string) error {
 }
 
 // oauthInMemoryCredentialsCache implements OAuthCredentialsCache without any filesystem access,
-// suitable for read-only containers. Activate by setting CAMUNDA_TOKEN_DISK_CACHE_DISABLE.
+// suitable for read-only containers. Activate by setting ZEEBE_CLIENT_DISK_CACHE_DISABLE.
 type oauthInMemoryCredentialsCache struct {
 	audiences map[string]*oauth2.Token
 	lock      sync.RWMutex

--- a/pkg/zbc/oauthCredentialsCache.go
+++ b/pkg/zbc/oauthCredentialsCache.go
@@ -27,6 +27,7 @@ import (
 )
 
 const OAuthCachePathEnvVar = "ZEEBE_CLIENT_CONFIG_PATH"
+const OAuthCacheDiskDisableEnvVar = "CAMUNDA_TOKEN_DISK_CACHE_DISABLE"
 const DefaultOAuthCacheFileDir = ".camunda"
 const DefaultOAuthCacheFile = "credentials"
 const oauthYamlCredentialsCachePerm = 0660
@@ -196,4 +197,38 @@ func ensureOAuthCachePathSegmentsExist(directory string) error {
 	}
 
 	return err
+}
+
+// oauthInMemoryCredentialsCache implements OAuthCredentialsCache without any filesystem access,
+// suitable for read-only containers. Activate by setting CAMUNDA_TOKEN_DISK_CACHE_DISABLE.
+type oauthInMemoryCredentialsCache struct {
+	audiences map[string]*oauth2.Token
+	lock      sync.RWMutex
+}
+
+// NewOAuthInMemoryCredentialsCache creates a new in-memory credentials cache that never touches the filesystem.
+func NewOAuthInMemoryCredentialsCache() OAuthCredentialsCache {
+	return &oauthInMemoryCredentialsCache{
+		audiences: make(map[string]*oauth2.Token),
+	}
+}
+
+// Refresh is a no-op for the in-memory cache since there is no external source to read from.
+func (cache *oauthInMemoryCredentialsCache) Refresh() error {
+	return nil
+}
+
+// Get returns the cached credentials for the given audience or nil.
+func (cache *oauthInMemoryCredentialsCache) Get(audience string) *oauth2.Token {
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+	return cache.audiences[audience]
+}
+
+// Update sets the credentials for the given audience in memory.
+func (cache *oauthInMemoryCredentialsCache) Update(audience string, token *oauth2.Token) error {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	cache.audiences[audience] = token
+	return nil
 }

--- a/pkg/zbc/oauthCredentialsCache_test.go
+++ b/pkg/zbc/oauthCredentialsCache_test.go
@@ -160,6 +160,36 @@ func copyCredentialsCacheGoldenFileToTempFile() string {
 	return path
 }
 
+func (s *oauthCredsCacheTestSuite) TestInMemoryCacheGetAndUpdate() {
+	cache := NewOAuthInMemoryCredentialsCache()
+
+	err := cache.Update(wombatAudience, wombat)
+	s.NoError(err)
+	err = cache.Update(aardvarkAudience, aardvark)
+	s.NoError(err)
+
+	s.EqualValues(wombat, cache.Get(wombatAudience))
+	s.EqualValues(aardvark, cache.Get(aardvarkAudience))
+}
+
+func (s *oauthCredsCacheTestSuite) TestInMemoryCacheRefreshIsNoOp() {
+	cache := NewOAuthInMemoryCredentialsCache()
+
+	err := cache.Update(wombatAudience, wombat)
+	s.NoError(err)
+
+	err = cache.Refresh()
+	s.NoError(err)
+
+	// data should still be there after refresh
+	s.EqualValues(wombat, cache.Get(wombatAudience))
+}
+
+func (s *oauthCredsCacheTestSuite) TestInMemoryCacheGetMiss() {
+	cache := NewOAuthInMemoryCredentialsCache()
+	s.Nil(cache.Get("unknown-audience"))
+}
+
 // helper to truncate the default cache file
 func truncateDefaultOAuthYamlCacheFile() {
 	err := os.Remove(DefaultOauthYamlCachePath)

--- a/pkg/zbc/oauthCredentialsProvider.go
+++ b/pkg/zbc/oauthCredentialsProvider.go
@@ -243,11 +243,15 @@ func applyCredentialDefaults(config *OAuthProviderConfig) {
 	}
 
 	if config.Cache == nil {
-		cache, err := NewOAuthYamlCredentialsCache("")
-		if err != nil {
-			log.Printf("Failed to create OAuth YAML token cache with default path: %s", err.Error())
+		if env.get(OAuthCacheDiskDisableEnvVar) != "" {
+			config.Cache = NewOAuthInMemoryCredentialsCache()
 		} else {
-			config.Cache = cache
+			cache, err := NewOAuthYamlCredentialsCache("")
+			if err != nil {
+				log.Printf("Failed to create OAuth YAML token cache with default path: %s", err.Error())
+			} else {
+				config.Cache = cache
+			}
 		}
 	}
 

--- a/pkg/zbc/oauthCredentialsProvider_test.go
+++ b/pkg/zbc/oauthCredentialsProvider_test.go
@@ -407,6 +407,44 @@ func (s *oauthCredsProviderTestSuite) TestAuthzUrlEnvOverride() {
 	s.EqualValues("https://envAuthzUrl", config.AuthorizationServerURL)
 }
 
+func (s *oauthCredsProviderTestSuite) TestInMemoryCacheUsedWhenEnvSet() {
+	// given
+	env.set(OAuthCacheDiskDisableEnvVar, "true")
+
+	config := &OAuthProviderConfig{
+		ClientID:               clientID,
+		ClientSecret:           clientSecret,
+		Audience:               audience,
+		AuthorizationServerURL: "https://example.com/oauth/token",
+	}
+
+	// when
+	provider, err := NewOAuthCredentialsProvider(config)
+
+	// then
+	s.NoError(err)
+	s.IsType(&oauthInMemoryCredentialsCache{}, provider.Cache)
+}
+
+func (s *oauthCredsProviderTestSuite) TestYamlCacheUsedWhenEnvNotSet() {
+	// given
+	truncateDefaultOAuthYamlCacheFile()
+
+	config := &OAuthProviderConfig{
+		ClientID:               clientID,
+		ClientSecret:           clientSecret,
+		Audience:               audience,
+		AuthorizationServerURL: "https://example.com/oauth/token",
+	}
+
+	// when
+	provider, err := NewOAuthCredentialsProvider(config)
+
+	// then
+	s.NoError(err)
+	s.IsType(&oauthYamlCredentialsCache{}, provider.Cache)
+}
+
 func (s *oauthCredsProviderTestSuite) TestOAuthCredentialsProviderCachesCredentials() {
 	// create fake gRPC server which returns UNAUTHENTICATED always except if we use the token `accessToken`
 	truncateDefaultOAuthYamlCacheFile()


### PR DESCRIPTION
## Description 
 
Adds an in-memory `OAuthCredentialsCache` implementation that can be activated via the `ZEEBE_CLIENT_DISK_CACHE_DISABLE` environment variable. When set, the client uses an in-memory token cache instead of persisting credentials to `~/.camunda/credentials`.
 
## Additional context 
 
When running Zeebe clients in containers with read-only filesystems (`readOnlyRootFilesystem: true` in Kubernetes), the default YAML-based credentials cache fails because it cannot create or write to the cache file.  
While a custom `OAuthCredentialsCache` can be injected programmatically via `OAuthProviderConfig.Cache`, an environment variable toggle is simpler for container deployments.
 
Note: If a custom cache is explicitly passed via `OAuthProviderConfig.Cache`, the environment variable is ignored.
 
## Testing changes 
 
- 3 new unit tests for the in-memory cache (`TestInMemoryCacheGetAndUpdate`, `TestInMemoryCacheRefreshIsNoOp`, `TestInMemoryCacheGetMiss`)
- 2 new integration tests for env var wiring (`TestInMemoryCacheUsedWhenEnvSet`, `TestYamlCacheUsedWhenEnvNotSet`) 
- All existing tests pass: `go test ./pkg/zbc/...` 
- `go vet ./pkg/zbc/...` clean 
 
## Types of changes 
- [ ] Bug fix (non-breaking change which fixes an existing open issue) 
- [x] New feature (non-breaking change which adds functionality to an extension) 
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change) 
- [x] Documentation update (changes made to an existing piece of documentation) 
 
## Checklist: 
- [x] My code adheres to the syntax used by this extension. 
- [x] My pull request requires a change to the documentation. 
- [x] I have updated the documentation accordingly. 
- [x] I have read the **Camunda Community Hub** documentation. 
- [x] I have read the **Pull Request Process** documentation. 
- [x] I have added or suggested tests to cover my changes suggested in this pull request. 
- [x] All new and existing CI/CD tests passed. 
- [ ] I will tag @/camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer. 