### PR TITLE
fix: make ExponentialBackoff concurrency-safe

### DIFF
--- a/pkg/worker/exponentialBackoffSupplier.go
+++ b/pkg/worker/exponentialBackoffSupplier.go
@@ -17,6 +17,7 @@ package worker
 import (
 	"math"
 	"math/rand"
+	"sync"
 	"time"
 )
 
@@ -36,6 +37,7 @@ func NewExponentialBackoffBuilder() ExponentialBackoff {
 		backoffFactor: 1.6,
 		jitterFactor:  0.1,
 		random:        rand.New(rand.NewSource(time.Now().Unix())), //nolint G404, we dont need a secure random number generator
+		randomMu:      &sync.Mutex{},
 	}
 }
 
@@ -65,12 +67,17 @@ func (e ExponentialBackoff) Random(random *rand.Rand) ExponentialBackoffBuilder 
 }
 
 func (e ExponentialBackoff) Build() BackoffSupplier {
+	mu := e.randomMu
+	if mu == nil {
+		mu = &sync.Mutex{}
+	}
 	return ExponentialBackoff{
 		minDelay:      e.minDelay,
 		maxDelay:      e.maxDelay,
 		backoffFactor: e.backoffFactor,
 		jitterFactor:  e.jitterFactor,
 		random:        e.random,
+		randomMu:      mu,
 	}
 }
 
@@ -78,6 +85,10 @@ type ExponentialBackoff struct {
 	minDelay, maxDelay          time.Duration
 	backoffFactor, jitterFactor float64
 	random                      *rand.Rand
+	// randomMu guards random, which is not safe for concurrent use. It is a
+	// pointer so that value-receiver copies of ExponentialBackoff share the
+	// same lock as they share the same random source.
+	randomMu *sync.Mutex
 }
 
 func (e ExponentialBackoff) SupplyRetryDelay(currentRetryDelay time.Duration) time.Duration {
@@ -92,5 +103,11 @@ func (e ExponentialBackoff) computeJitter(value float64) float64 {
 	minFactor := value * -e.jitterFactor
 	maxFactor := value * e.jitterFactor
 
-	return (e.random.Float64() * (maxFactor - minFactor)) + minFactor
+	// rand.Rand is not safe for concurrent use; multiple job pollers share this
+	// supplier and call SupplyRetryDelay concurrently.
+	e.randomMu.Lock()
+	random := e.random.Float64()
+	e.randomMu.Unlock()
+
+	return (random * (maxFactor - minFactor)) + minFactor
 }

--- a/pkg/worker/exponentialBackoffSupplier_test.go
+++ b/pkg/worker/exponentialBackoffSupplier_test.go
@@ -17,6 +17,7 @@ package worker
 import (
 	"github.com/stretchr/testify/assert"
 	"math"
+	"sync"
 	"testing"
 	"time"
 )
@@ -113,4 +114,30 @@ func TestExponentialBackoffSupplier_ShouldBeRandomizedWithJitter(t *testing.T) {
 		// then - as we used 0 for jitter factor, we can guarantee all are sorted
 		assert.IsIncreasing(t, delay, retryDelays[i-1], "backoff is strictly increasing")
 	}
+}
+
+// TestExponentialBackoffSupplier_IsConcurrencySafe reproduces the panic that
+// occurred when multiple job pollers shared a single supplier and called
+// SupplyRetryDelay concurrently, corrupting the shared *rand.Rand. Run with
+// -race to catch the data race.
+func TestExponentialBackoffSupplier_IsConcurrencySafe(t *testing.T) {
+	e := NewExponentialBackoffBuilder().
+		JitterFactor(0.1).
+		Build()
+
+	const goroutines = 50
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			delay := time.Millisecond * 50
+			for i := 0; i < iterations; i++ {
+				delay = e.SupplyRetryDelay(delay)
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
[Data race in ExponentialBackoff supplier causes "index out of range" panic under concurrent polling](https://github.com/camunda-community-hub/zeebe-client-go/issues/59#top)


- Guard shared random source with a mutex to prevent concurrent access
- Fix race condition in defaultBackoffSupplier during retry delay generation
- Prevent "index out of range" panics when multiple job pollers call SupplyRetryDelay simultaneously



## Description

`ExponentialBackoff` uses a shared package-level `defaultBackoffSupplier`, which contains a single `*rand.Rand` instance. Since `math/rand.Rand` is not concurrency-safe, concurrent calls to `SupplyRetryDelay()` can corrupt the RNG state and cause panics such as:

```text
panic: runtime error: index out of range [-2]
```

This change makes the shared supplier concurrency-safe by protecting access to the random source with a mutex.

### Changes

* Add a shared mutex to `ExponentialBackoff`
* Initialize the mutex in the builder
* Lock around `e.random.Float64()` in `computeJitter`

### Testing

* Added a concurrency regression test that invokes `SupplyRetryDelay()` from multiple goroutines against a shared supplier
* Verified with `go test -race ./pkg/worker/...`
* Verified build passes successfully

## Fixes

Fixes #<ISSUE_NUMBER>

## Type of Change

* [x] Bug fix (non-breaking change)

## Checklist

* [x] Tests added/updated
* [x] Existing tests pass
* [x] No breaking API changes
