### PR TITLE
fix(worker): make ExponentialBackoff safe for concurrent use

### DIFF
--- a/pkg/worker/exponentialBackoffSupplier.go
+++ b/pkg/worker/exponentialBackoffSupplier.go
@@ -17,6 +17,7 @@ package worker
 import (
 	"math"
 	"math/rand"
+	"sync"
 	"time"
 )
 
@@ -36,6 +37,7 @@ func NewExponentialBackoffBuilder() ExponentialBackoff {
 		backoffFactor: 1.6,
 		jitterFactor:  0.1,
 		random:        rand.New(rand.NewSource(time.Now().Unix())), //nolint G404, we dont need a secure random number generator
+		randomMu:      &sync.Mutex{},
 	}
 }
 
@@ -71,6 +73,7 @@ func (e ExponentialBackoff) Build() BackoffSupplier {
 		backoffFactor: e.backoffFactor,
 		jitterFactor:  e.jitterFactor,
 		random:        e.random,
+		randomMu:      e.randomMu,
 	}
 }
 
@@ -78,6 +81,9 @@ type ExponentialBackoff struct {
 	minDelay, maxDelay          time.Duration
 	backoffFactor, jitterFactor float64
 	random                      *rand.Rand
+	// randomMu guards random, which is a shared *rand.Rand and is not safe for
+	// concurrent use. Multiple job pollers may back off at the same time.
+	randomMu *sync.Mutex
 }
 
 func (e ExponentialBackoff) SupplyRetryDelay(currentRetryDelay time.Duration) time.Duration {
@@ -92,5 +98,16 @@ func (e ExponentialBackoff) computeJitter(value float64) float64 {
 	minFactor := value * -e.jitterFactor
 	maxFactor := value * e.jitterFactor
 
-	return (e.random.Float64() * (maxFactor - minFactor)) + minFactor
+	return (e.float64() * (maxFactor - minFactor)) + minFactor
+}
+
+// float64 returns a random float in [0.0, 1.0), guarding the shared *rand.Rand
+// so concurrent pollers do not corrupt its internal state.
+func (e ExponentialBackoff) float64() float64 {
+	if e.randomMu == nil {
+		return e.random.Float64()
+	}
+	e.randomMu.Lock()
+	defer e.randomMu.Unlock()
+	return e.random.Float64()
 }

--- a/pkg/worker/exponentialBackoffSupplier_test.go
+++ b/pkg/worker/exponentialBackoffSupplier_test.go
@@ -17,6 +17,7 @@ package worker
 import (
 	"github.com/stretchr/testify/assert"
 	"math"
+	"sync"
 	"testing"
 	"time"
 )
@@ -113,4 +114,25 @@ func TestExponentialBackoffSupplier_ShouldBeRandomizedWithJitter(t *testing.T) {
 		// then - as we used 0 for jitter factor, we can guarantee all are sorted
 		assert.IsIncreasing(t, delay, retryDelays[i-1], "backoff is strictly increasing")
 	}
+}
+
+func TestExponentialBackoffSupplier_IsSafeForConcurrentUse(t *testing.T) {
+	// A single supplier is shared by every job poller, so SupplyRetryDelay must
+	// be safe to call from multiple goroutines. Run under -race to catch the
+	// unsynchronized *rand.Rand access.
+	e := NewExponentialBackoffBuilder().
+		JitterFactor(0.1).
+		Build()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				e.SupplyRetryDelay(time.Millisecond * 50)
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
The default backoff supplier is a package-level singleton (`defaultBackoffSupplier`), so every job poller that doesn't set its own supplier shares one `ExponentialBackoff`. Its `random` field is a `*rand.Rand`, which is not safe for concurrent use, and `Build()` copies the struct but keeps the same pointer. When several pollers back off at the same time (broker instability, empty polls), concurrent `Float64()` calls corrupt the source's internal indices and panic with `index out of range`.

This guards the shared `random` behind a mutex that is threaded through the builder, so `SupplyRetryDelay` is safe to call from multiple goroutines. The public API is unchanged. Added a regression test that hammers a single supplier from many goroutines and fails under `-race` before the fix.

Fixes #59
